### PR TITLE
Change button font style

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -837,6 +837,7 @@ color:white !important;
     color:#000000;
     font-size:28px;
     font-weight:300;
+    font-style: italic;
     padding:20px 30px;
     text-decoration:none;
 }


### PR DESCRIPTION
This closes #2. Since the Roboto import only includes the italic
version, Safari was refusing to use it without this.