### PR TITLE
Update to use Ghost’s user-editable navigation

### DIFF
--- a/.content-overrides/settings/routes.yaml
+++ b/.content-overrides/settings/routes.yaml
@@ -1,0 +1,17 @@
+# For preview deployment only… maybe?
+routes:
+  /:
+    data: page.home
+    template: home
+
+collections:
+  /blog/:
+    permalink: /blog/{slug}/
+    template: index
+  /:
+    permalink: /{slug}/
+    template: home
+
+taxonomies:
+  tag: /tag/{slug}/
+  author: /author/{slug}/

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -43,6 +43,8 @@ jobs:
         run: rm -rf themenamehere/.git
       - name: mv theme
         run: mv themenamehere ghost-on-heroku/content/themes
+      - name: copy content overrides
+        run: cp -Rv ghost-on-heroku/content/themes/themenamehere/.content-overrides/* ghost-on-heroku/content
       - name: hack .gitignore
         working-directory: ghost-on-heroku
         run: sed -i 's/content\/themes\/\*//' .gitignore

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -17,6 +17,11 @@
         grid-column-gap: 1rem;
     }
 }
+.page-template .header {
+    background-color: rgba(34,34,34,0.9);
+    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
+    margin-bottom: 50px;
+}
 .active {
     background-color: rgba(34, 34, 34, 0.8);
 }

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -199,6 +199,9 @@
     .header .nav {
         max-height: 0;
     }
+    .header .nav li {
+        width: 100%;
+    }
     .header .menu-btn:checked ~ .nav {
         clear: both;
         text-align: center;

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -142,9 +142,8 @@
     }
 }
 
-.header .menu {
+.header .nav {
     clear: both;
-    max-height: 0;
     transition: max-height 0.2s ease-out;
 }
 .header .menu-icon {
@@ -183,11 +182,6 @@
 .header .menu-btn {
     display: none;
 }
-.header .menu-btn:checked ~ .menu {
-    text-align: center;
-    max-height: 240px;
-    margin-bottom: 20px;
-}
 .header .menu-btn:checked ~ .menu-icon .navicon {
     background: transparent;
 }
@@ -201,17 +195,33 @@
 .header .menu-btn:checked ~ .menu-icon:not(.steps) .navicon:after {
     top: 0;
 }
+@media screen and (max-width: 768px) {
+    .header .nav {
+        max-height: 0;
+    }
+    .header .menu-btn:checked ~ .nav {
+        clear: both;
+        text-align: center;
+        max-height: 240px;
+        margin-bottom: 20px;
+    }
+    .home-template .header .menu-btn:checked ~ .nav:after {
+        background-color: rgba(34, 34, 34, 0.8);
+        position: absolute;
+        top: 0;
+        bottom: 1em;
+        left: 0;
+        right: 0;
+        z-index: -1;
+        content: '';
+    }
+}
 @media (min-width: 48em) {
     .header li {
         float: left;
     }
     .header li a {
         margin: 20px 30px;
-    }
-    .header .menu {
-        clear: none;
-        float: right;
-        max-height: none;
     }
     .header .menu-icon {
         display: none;

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -116,7 +116,7 @@
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 }
 
-.donate-button {
+.nav-donate a {
     margin-right: 0px;
     display: inline-block;
     font-size: 25px;
@@ -131,7 +131,7 @@
 }
 
 @media screen and (min-width: 768px) {
-    .donate-button {
+    .nav-donate a {
         margin-right: 50px;
         font-size: 25px;
     }
@@ -213,11 +213,17 @@
     }
 }
 
-.nav-hover {
+.header nav ul.nav {
+  display: flex;
+  align-items: center;
+  text-transform: uppercase;
+}
+
+.header nav ul.nav a {
   /*font-size: 36px;*/
   /*font-weight: bold;*/
   text-decoration: none;
-  color: black;
+  color: white;
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(65%, transparent), color-stop(0, #fcf113));
   background-image: linear-gradient(180deg, transparent 65%, white 0);
   background-repeat: no-repeat;
@@ -226,15 +232,15 @@
   transition: background-size .2s ease;
 }
 
-.nav-hover:hover {
+.header nav ul.nav a:hover {
   background-size: 100% 130%;
 }
 
-.nav-current {
+.header nav ul.nav .nav-current a {
   /*font-size: 36px;*/
   /*font-weight: bold;*/
   text-decoration: none;
-  color: black;
+  color: white;
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(65%, transparent), color-stop(0, #fcf113));
   background-image: linear-gradient(180deg, transparent 65%, white 0);
   background-repeat: no-repeat;

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -241,6 +241,10 @@
   background-size: 100% 130%;
 }
 
+.header nav ul.nav .nav-donate a:hover {
+  background-size: 0 130%;
+}
+
 .header nav ul.nav .nav-current a {
   /*font-size: 36px;*/
   /*font-weight: bold;*/

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -17,7 +17,7 @@
         grid-column-gap: 1rem;
     }
 }
-.page-template .header {
+.page-template .header, .blog-template .header, .post-template .header {
     background-color: rgba(34,34,34,0.9);
     box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
     margin-bottom: 50px;

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -254,10 +254,6 @@
   background-size: 100% 130%;
 }
 
-.header nav ul.nav .nav-donate a:hover {
-  background-size: 0 130%;
-}
-
 .header nav ul.nav .nav-current a {
   /*font-size: 36px;*/
   /*font-weight: bold;*/
@@ -268,3 +264,8 @@
   background-repeat: no-repeat;
   background-size: 100% 130%;
 }
+
+.header nav ul.nav .nav-donate a:hover, .header nav ul.nav .nav-donate.nav-current a {
+    background-size: 0 130%;
+  }
+  

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -116,7 +116,7 @@
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 }
 
-.nav-donate a {
+.header nav ul.nav .nav-donate a {
     margin-right: 0px;
     display: inline-block;
     font-size: 25px;

--- a/default.hbs
+++ b/default.hbs
@@ -36,20 +36,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header" style="background-color: rgba(34,34,34,0.9);
-    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
-            <nav>
-                <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
-                <ul class="menu">
-                    <li><a class="nav-hover" href="/#mission" >MISSION</a></li>
-                    <li><a class="nav-hover" href="/resources">RESOURCES</a></li>
-                    <li ><a class="nav-current" href="/blog">BLOG</a></li>
-                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
-                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
             
             <!--<section><h3>Recent posts from the blog</h3><ul><li> <a href="/blog/the-most-recent-post-so-far">The most recent post so far</a></li><li> <a href="/blog/a-simple-post">A simple blog post</a></li><li> <a href="/blog/another-post">Another post</a></li></ul></section>-->
         

--- a/default.hbs
+++ b/default.hbs
@@ -33,8 +33,7 @@
     {{ghost_head}}
 </head>
 
-<body class="{{body_class}}">
-
+<body class="{{body_class}} {{#is "blog"}}blog-template{{/is}}">
 
     {{> nav}}
             

--- a/home.hbs
+++ b/home.hbs
@@ -37,19 +37,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header" id="myHeader">
-            <nav>
-                 {{> logo}} <input onclick="myFunction()" class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label>
-                <ul class="menu">
-                    <li ><a class="nav-current" href="/#mission" data-current="current page">MISSION</a></li>
-                    <li><a class="nav-hover" href="/resources">RESOURCES</a></li>
-                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
-                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
-                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
 
         <div class="hero2">
             <div  class="text-heading">

--- a/home.hbs
+++ b/home.hbs
@@ -156,13 +156,6 @@
     <script src="{{asset "js/bootstrap.min.js"}}"></script>
     <script src="{{asset "js/main.js"}}"></script>
     <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-    <script type="text/javascript"> 
-
-    function myFunction() {
-  var element = document.getElementById("myHeader");
-  element.classList.add("active");
-}
-    </script>
   <script>
     AOS.init({
         once: true

--- a/page-blog.hbs
+++ b/page-blog.hbs
@@ -34,19 +34,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header">
-            <nav>
-                {{> logo}} <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label>
-                <ul class="menu">
-                    <li><a href="/">MISSION</a></li>
-                    <li><a href="/resources">RESdfsdfOURCES</a></li>
-                    <li style="text-decoration-line: underline;" data-current="current page"><a href="/blog">BLOG</a></li>
-                    <li><a href="/contact">CONTACT</a></li>
-                    <li><button type="button" class="donate-button">DONATE</button></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
 
         <div class="hero">
             <div class="text-heading">

--- a/page-contact.hbs
+++ b/page-contact.hbs
@@ -36,20 +36,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header" style="background-color: rgba(34,34,34,0.9);
-    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
-            <nav>
-                 <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
-                <ul class="menu">
-                    <li><a class="nav-hover" href="/#mission">MISSION</a></li>
-                    <li><a class="nav-hover" href="/resources">RESOURCES</a></li>
-                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
-                    <li><a class="nav-current" href="/contact">CONTACT</a></li>
-                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
 
         
     <div class="hero">

--- a/page-donate.hbs
+++ b/page-donate.hbs
@@ -36,20 +36,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header" style="background-color: rgba(34,34,34,0.9);
-    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
-            <nav>
-                <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label>
-                <ul class="menu">
-                    <li><a class="nav-hover" href="/#mission">MISSION</a></li>
-                    <li ><a class="nav-hover" href="/resources" data-current="current page">RESOURCES</a></li>
-                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
-                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
-                    <li > <a href="/donate"><button type="button" class="donate-button ">DONATE</button> </a></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
 
         
     <div id="mission" class="section-1">

--- a/page-resources.hbs
+++ b/page-resources.hbs
@@ -36,20 +36,7 @@
 <body class="{{body_class}}">
 
 
-    {{!-- Navigation bar --}}
-    <header class="header" style="background-color: rgba(34,34,34,0.9);
-    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
-            <nav>
-                <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label>
-                <ul class="menu">
-                    <li><a class="nav-hover" href="/#mission">MISSION</a></li>
-                    <li><a class="nav-current" href="/resources">RESOURCES</a></li>
-                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
-                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
-                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
-                </ul>
-            </nav>
-        </header>
+    {{> nav}}
 
         
     <div id="mission" data-aos="fade-up" class="section-1">

--- a/partials/logo.hbs
+++ b/partials/logo.hbs
@@ -1,1 +1,0 @@
-<img class="header-logo" src="{{asset "images/logo.png"}}" />

--- a/partials/nav.hbs
+++ b/partials/nav.hbs
@@ -1,6 +1,9 @@
     <header class="header">
             <nav>
-                <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
+                <a href="/">
+                    <img class="header-logo" src="{{asset "images/logo.png"}}" />
+                </a>
+                <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
                 {{#if @site.navigation}}
                     {{navigation}}
                 {{/if}}

--- a/partials/nav.hbs
+++ b/partials/nav.hbs
@@ -1,6 +1,4 @@
-    <header class="header" style="background-color: rgba(34,34,34,0.9);
-    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
-        {{!-- FIXME the inline style is only meant for blog, contact, donate --}}
+    <header class="header">
             <nav>
                 <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
                 {{#if @site.navigation}}

--- a/partials/nav.hbs
+++ b/partials/nav.hbs
@@ -3,12 +3,8 @@
         {{!-- FIXME the inline style is only meant for blog, contact, donate --}}
             <nav>
                 <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
-                <ul class="menu">
-                    <li><a class="nav-hover" href="/#mission" >MISSION</a></li>
-                    <li><a class="nav-hover" href="/resources">RESOURCES</a></li>
-                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
-                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
-                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
-                </ul>
+                {{#if @site.navigation}}
+                    {{navigation}}
+                {{/if}}
             </nav>
         </header>

--- a/partials/nav.hbs
+++ b/partials/nav.hbs
@@ -1,11 +1,16 @@
-    <header class="header">
-            <nav>
-                <a href="/">
-                    <img class="header-logo" src="{{asset "images/logo.png"}}" />
-                </a>
-                <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
-                {{#if @site.navigation}}
-                    {{navigation}}
-                {{/if}}
-            </nav>
-        </header>
+<header class="header">
+  <nav>
+    <a href="/">
+      <img class="header-logo" src="{{asset "images/logo.png"}}" />
+    </a>
+
+    <input class="menu-btn" type="checkbox" id="menu-btn" />
+    <label class="menu-icon" for="menu-btn">
+      <span class="navicon"></span>
+    </label>
+
+    {{#if @site.navigation}}
+      {{navigation}}
+    {{/if}}
+  </nav>
+</header>

--- a/partials/nav.hbs
+++ b/partials/nav.hbs
@@ -1,0 +1,14 @@
+    <header class="header" style="background-color: rgba(34,34,34,0.9);
+    box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22); margin-bottom: 50px;">
+        {{!-- FIXME the inline style is only meant for blog, contact, donate --}}
+            <nav>
+                <a href="/"> {{> logo}} </a> <input class="menu-btn" type="checkbox" id="menu-btn" /> <label class="menu-icon" for="menu-btn"><span class="navicon"></span></label> 
+                <ul class="menu">
+                    <li><a class="nav-hover" href="/#mission" >MISSION</a></li>
+                    <li><a class="nav-hover" href="/resources">RESOURCES</a></li>
+                    <li><a class="nav-hover" href="/blog">BLOG</a></li>
+                    <li><a class="nav-hover" href="/contact">CONTACT</a></li>
+                    <li> <a href="/donate"><button type="button" class="donate-button">DONATE</button> </a></li>
+                </ul>
+            </nav>
+        </header>


### PR DESCRIPTION
This closes #3. It converts the theme to use Ghost’s built-in navigation features rather than hard-coding links to pages. That means it’ll be easier for non-computer nerds to keep the site updated 🥳

You can [check it out](https://ghost-theme-sandbox.herokuapp.com/) on the theme “sandbox” site. It has different navigation than the true site to highlight this difference.