### PR TITLE
Change title text to be smaller

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -536,7 +536,7 @@ html[data-current="contact"] main > form button {
     padding-left: 25px;
     transform: rotate(-5deg);
     font-style: italic;
-    font-size: 3.2rem;
+    font-size: 3rem;
     font-family: 'Roboto', sans-serif;
 }
 


### PR DESCRIPTION
This is an unfortunate way to close #5. I’d prefer to be able
to clip overflow or something but that didn’t seem to work…?
But this does make the page no longer scroll horizontally, at
least the two phones I’ve tried.