### PR TITLE
Fix post image alignment and caption size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -640,6 +640,7 @@ article figure {
 
 article figcaption {
     text-align: center;
+    font-size: 75%;
 }
 
 body {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -634,6 +634,11 @@ article img {
     margin-right: -50vw;
 }
 
+article > figure {
+    display: flex;
+    justify-content: center;
+}
+
 article figure {
     margin: 0;
 }


### PR DESCRIPTION
These are some changes requested by a blog post author 🤓

Here’s an example of the post image alignment change:

![image](https://user-images.githubusercontent.com/43280/98867803-cbbd1d00-2434-11eb-9e4b-2e51fe2b5c3e.png)

And the caption being smaller:

![image](https://user-images.githubusercontent.com/43280/98867868-ed1e0900-2434-11eb-8923-aea2f0842818.png)

These screenshots are from Percy (as in progress in #41) but I’m manually pasting them here until I can get the WPCH organisation set up in Percy.