### PR TITLE
Fix aspect ratio of post image

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -637,6 +637,7 @@ article img {
 article > figure {
     display: flex;
     justify-content: center;
+    align-items: center;
 }
 
 article figure {


### PR DESCRIPTION
This fixes it for me in macOS Safari responsive design mode. I’m pressed for time and can’t easily test it on true mobile Safari but it’s surely the same??? 🤞

Hopefully this doesn’t break anything else 😳