### PR TITLE
Add display of MLA details

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1142,7 +1142,7 @@ button:focus {
     opacity: 0.5;
 }
 
-.tag-hash-contact-council #council-information {
+.tag-hash-contact-council #council-information, .tag-hash-contact-council #manitoba-information {
     margin-top: 2rem;
     border: 1px solid black;
 }

--- a/post.hbs
+++ b/post.hbs
@@ -341,7 +341,7 @@ References
                                 handleNewLocation(mapsMouseEvent.latLng);
                             });
 
-                            fetch(ADDRESS_TO_WARD_HOST + '/council-wards.geojson').then(r => r.json()).then(json => {
+                            fetch(ADDRESS_TO_WARD_HOST + '/manitoba-electoral-divisions-simplified.geojson').then(r => r.json()).then(json => {
                                 map.data.addGeoJson(json);
                                 map.data.setStyle(geojsonStyle);
                             });

--- a/post.hbs
+++ b/post.hbs
@@ -42,6 +42,7 @@ into the {body} of the default.hbs template --}}
                 </div>
             </section>
 
+            {{!-- FIXME how to generalise/make more flexible? Council only, MLAs only, both, etc --}}
             {{#has tag="#contact-council"}}
                 <script src="https://cdn.jsdelivr.net/npm/vue"></script>
                 <script src="/assets/js/vue-clipboard.min.js"></script>
@@ -95,6 +96,21 @@ References
                     </div>
 
                     <div id="status"></div>
+
+                    <div id="manitoba-information" class="jurisdiction">
+                        <header>
+                            <h3 v-html="divisionHeader">Manitoba electoral division</h3>
+                        </header>
+
+                        <div id="mla-information">
+                            <ul>
+                                <person-card
+                                    v-bind:person='person'
+                                    v-bind:key='person.name'>
+                                </person-card>
+                            </ul>
+                        </div>
+                    </div>
 
                     <div id="council-information" class="jurisdiction">
                         <header>
@@ -282,7 +298,7 @@ References
                         });
                     });
 
-                    var councilWardVue, locateMeVue;
+                    var councilWardVue, manitobaDivisionVue, locateMeVue;
 
                     councilWardVue = new Vue({
                         el: '#council-information header',
@@ -295,6 +311,22 @@ References
                                     return `${this.council.ward} city council ward`;
                                 } else {
                                     return 'Unknown city council ward';
+                                }
+                            },
+                        },
+                    });
+
+                    manitobaDivisionVue = new Vue({
+                        el: '#manitoba-information header',
+                        data: {
+                            manitoba: undefined,
+                        },
+                        computed: {
+                            divisionHeader: function() {
+                                if (this.manitoba && this.manitoba.division) {
+                                    return `${this.manitoba.division} Manitoba electoral division`;
+                                } else {
+                                    return 'Unknown Manitoba electoral division';
                                 }
                             },
                         },
@@ -313,6 +345,21 @@ References
                         data: {
                             person: silhouetteCouncillor
                         }
+                    });
+
+                    var mlaVue;
+
+                    var silhouetteMla = {
+                        name: 'MLA',
+                        photo: '/photos/silhouette.png',
+                        placeholder: true,
+                    };
+
+                    mlaVue = new Vue({
+                        el: '#mla-information',
+                        data: {
+                            person: silhouetteMla,
+                        },
                     });
 
                     google.maps.event.addDomListener(window, 'load', function initialize() {
@@ -483,6 +530,7 @@ References
                         map.panTo(location);
 
                         $("#council-information").hide();
+                        $("#manitoba-information").hide();
 
                         updateStatus('Searching…');
 
@@ -509,18 +557,25 @@ References
 
                         councillorVue.$data.personList = silhouetteCouncillor;
 
-                        var ward = 'Not found';
+                        var division = 'Not found';
 
                         if (json.council) {
                             councilWardVue.$data.council = json.council;
                             displayCouncilInformation(json.council);
+                        } else {
+                            councilWardVue.$data.council = undefined;
+                        }
 
-                            ward = json.council.ward;
+                        if (json.manitoba) {
+                            manitobaDivisionVue.$data.manitoba = json.manitoba;
+                            displayManitobaInformation(json.manitoba);
+
+                            division = json.manitoba.division;
 
                             map.data.setStyle(function(feature) {
-                                const fw = feature.getProperty('name');
+                                const fw = feature.getProperty('ED');
 
-                                if (fw == ward) {
+                                if (fw == division) {
                                     return Object.assign({}, geojsonStyle, {
                                         fillColor: '#dc3545',
                                         fillOpacity: 0.5,
@@ -531,9 +586,9 @@ References
                                         fillOpacity: 0.2,
                                     });
                                 }
-                            })
+                            });
                         } else {
-                            councilWardVue.$data.council = undefined;
+                            manitobaDivisionVue.$data.manitoba = undefined;
                             map.data.setStyle(function(feature) {
                                     return Object.assign({}, geojsonStyle, {
                                         fillColor: '#dc3545',
@@ -550,6 +605,11 @@ References
                     function displayCouncilInformation(council) {
                         councillorVue.$data.person = council.councillor;
                         $('#council-information').show();
+                    }
+
+                    function displayManitobaInformation(manitoba) {
+                        mlaVue.$data.person = manitoba.member;
+                        $('#manitoba-information').show();
                     }
                 </script>
             {{/has}}

--- a/post.hbs
+++ b/post.hbs
@@ -358,7 +358,6 @@ References
                             );
 
                             autocompleteInput = document.getElementById('autocomplete');
-                            autocompleteInput.focus();
                             var autocomplete = new google.maps.places.Autocomplete(autocompleteInput, { bounds });
 
                             autocomplete.addListener('place_changed', function() {

--- a/post.hbs
+++ b/post.hbs
@@ -202,18 +202,18 @@ References
                                 </div>
                                 <div class='person-details'>
                                     <div class='name' v-html="person.name"></div>
-                                    <div class='phone row' v-if="person.phone">
-                                        <span v-html='person.phone' />
+                                    <div class='phone row' v-if="phone">
+                                        <span v-html='phone' />
                                         <div class='actions'>
                                             <a class='action-button' :href="telHref" v-on:click='onPhone'>Call </a>
-                                            <copy-button v-bind:copy='person.phone' />
+                                            <copy-button v-bind:copy='phone' />
                                         </div>
                                     </div>
-                                    <div class='person-email row' v-if="person.email">
-                                        <span v-html='person.email' />
+                                    <div class='person-email row' v-if="email">
+                                        <span v-html='email' />
                                         <div class='actions'>
                                             <a class='action-button' :href="mailtoHref" v-on:click='onOpenEmail'>Open email</a>
-                                            <copy-button v-bind:copy='person.email' text='Copy email' />
+                                            <copy-button v-bind:copy='email' text='Copy email' />
                                         </div>
                                     </div>
                                     <p v-if='mailtoFailed'>Some configurations may not be able to open email as desired. You can copy the email address and then copy the draft letter above.</p>
@@ -235,10 +235,15 @@ References
                             var randomSubject = emailSubjects[emailSubjects.length * Math.random() | 0];;
                             var photoPath = ADDRESS_TO_WARD_HOST + this.person.photo;
 
+                            var phone = this.person.constituencyPhone || this.person.phone;
+                            var email = this.person.constituencyEmail || this.person.email;
+
                             return {
-                                mailtoHref: `mailto:${this.person.email}?subject=${encodeURIComponent(randomSubject)}&bcc=wpgpolicecauseharm%40gmail.com&body=${councillorEmailBody.replace('RECIPIENTNAME', recipientName)}`,
+                                phone: phone,
+                                email: email,
+                                mailtoHref: `mailto:${email}?subject=${encodeURIComponent(randomSubject)}&bcc=wpgpolicecauseharm%40gmail.com&body=${councillorEmailBody.replace('RECIPIENTNAME', recipientName)}`,
                                 photoPath: photoPath,
-                                telHref: `tel:${this.person.phone}`,
+                                telHref: `tel:${phone}`,
 
                                 emailId: makeSafeForCSS(this.person.name),
 
@@ -252,7 +257,7 @@ References
                         },
                         methods: {
                             onOpenEmail: function(e) {
-                                maybeSend('OpenEmail', 'Email', this.person.email);
+                                maybeSend('OpenEmail', 'Email', this.email);
 
                                 var timeout = setTimeout(function() {
                                     maybeSend('MailtoFailed');
@@ -265,7 +270,7 @@ References
                             },
 
                             onPhone: function(e) {
-                                maybeSend('Phone', 'Phone', this.person.phone);
+                                maybeSend('Phone', 'Phone', this.phone);
                             },
                         }
                     });


### PR DESCRIPTION
The council version of this was a mess and this continues to be. Perhaps the best approach here is to have this importable via a `<script>` with various configuration options? 🤔

I’m opening this PR to gather feedback/refine the implementation before next week’s campaign.

* [ ] determine whether form letter is a thing
* [ ] different letters for councillors vs MLAs?
* [ ] should councillors even show?
* [ ] allow showing council only vs council and MB, etc
* [ ] extract letter somehow so this doesn’t change the December “Our city is unwell” iteration