### PR TITLE
Update theme for Ghost v4

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -662,7 +662,7 @@ blockquote::after{
 }
 
 article img {
-    height: 20rem;
+    height: auto;
     object-fit: cover;
     display: block;
     max-width: 100%;

--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>

--- a/home.hbs
+++ b/home.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>

--- a/page-blog.hbs
+++ b/page-blog.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>

--- a/page-contact.hbs
+++ b/page-contact.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>

--- a/page-get-involved.hbs
+++ b/page-get-involved.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>

--- a/page.hbs
+++ b/page.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
     <title>{{meta_title}}</title>


### PR DESCRIPTION
These are some minor changes to prepare for migrating to Ghost v4.

The significant one is changing the height of images in articles to `auto`,
as suggested [in the migration guide](https://ghost.org/docs/changes/#ghost-40).

When I do that locally, before and after:

![image](https://user-images.githubusercontent.com/43280/115154107-c5b01580-a03e-11eb-8b72-a893e4a0d701.png)

![image](https://user-images.githubusercontent.com/43280/115154126-dfe9f380-a03e-11eb-9f40-669a4e4a34d0.png)

This is what it looks like on v4 without this change:

![image](https://user-images.githubusercontent.com/43280/115154146-027c0c80-a03f-11eb-85b5-4b4976fa6091.png)

It seems preferable to me to show the full height of the image 🤔 

Something unfortunate is that the Heroku-adapted version of Ghost used for preview deployments [isn’t yet updated for v4](https://github.com/SNathJr/ghost-on-heroku/pull/78), but hopefully that can be updated soon.