### PR TITLE
Add footer helper

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -91,7 +91,7 @@
     AOS.init();
   </script>
 
-
+    {{ghost_foot}}
 
 </body>
 


### PR DESCRIPTION
There’s a warning about this when running `yarn test` and
it sometimes temporarily vexes me when I try adding something
to the footer on a post.