### PR TITLE
Remove unused engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "description": "A custom Ghost theme",
   "version": "0.0.1",
   "engines": {
-    "ghost": ">=3.0.0",
-    "ghost-api": "v3"
+    "ghost": ">=3.0.0"
   },
   "license": "gpl-3.0",
   "author": {


### PR DESCRIPTION
This is one of the `gscan` warnings, before:

<img width="776" alt="wpch-ghost-theme 2023-12-12 16-48-14" src="https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/assets/43280/66ddde02-e035-437e-89bc-f2d1449e39f6">

After:

<img width="771" alt="wpch-ghost-theme 2023-12-12 16-48-37" src="https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/assets/43280/7bf9c17d-b47f-47d5-9891-9ac07e36a1d4">

I don’t know why the `foreach` would go away…?

In Github Actions the [script](https://github.com/winnipegpolicecauseharm/wpch-ghost-theme/blob/e8550653269fa5cb8a65dfabb27f5ee46da063b1/package.json#L41) for testing the theme only cares about `--fatal` errors, we could make it more thorough if we want better exposure for this, or even add another parallel job that warns us but doesn’t fail the build 🤔
