### PR TITLE
Fix caption positioning

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -702,18 +702,15 @@ article img {
     margin-right: -50vw;
 }
 
-article > figure {
+article figure {
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
 }
 
-article figure {
-    margin: 0;
-}
-
 article figcaption {
+    padding-top: 5px;
     text-align: center;
     font-size: 75%;
 }


### PR DESCRIPTION
This closes #8. It’s not clear to me why direct figure children of article were the only ones centred.